### PR TITLE
BiometricPromptInfo Data Class for Cleaner API

### DIFF
--- a/biometricks/src/main/java/com/handstandsam/biometricks/BiometricPromptInfo.kt
+++ b/biometricks/src/main/java/com/handstandsam/biometricks/BiometricPromptInfo.kt
@@ -1,0 +1,27 @@
+package com.handstandsam.biometricks
+
+import androidx.biometric.BiometricPrompt
+
+/**
+ * This will force you to pass [BiometricPrompt.CryptoObject] and deviceCredentialAllowed to false.
+ *
+ * See Javadocs for [BiometricPrompt.PromptInfo.Builder]
+ *
+ * https://developer.android.com/reference/androidx/biometric/BiometricPrompt.PromptInfo.Builder
+ */
+class BiometricPromptInfo(
+    /** Required */
+    val title: String,
+    val negativeButtonText: String,
+    val cryptoObject: BiometricPrompt.CryptoObject,
+
+    /** Optional */
+    val subtitle: String? = null,
+    val description: String? = null,
+    val confirmationRequired: Boolean = true
+) {
+    /**
+     * We are going to forcing use of [BiometricPrompt.CryptoObject], so this MUST be false.
+     */
+    val deviceCredentialAllowed: Boolean = false
+}

--- a/biometricks/src/main/java/com/handstandsam/biometricks/BiometricPromptInfo.kt
+++ b/biometricks/src/main/java/com/handstandsam/biometricks/BiometricPromptInfo.kt
@@ -18,10 +18,6 @@ class BiometricPromptInfo(
     /** Optional */
     val subtitle: String? = null,
     val description: String? = null,
+    val deviceCredentialAllowed: Boolean = false,
     val confirmationRequired: Boolean = true
-) {
-    /**
-     * We are going to forcing use of [BiometricPrompt.CryptoObject], so this MUST be false.
-     */
-    val deviceCredentialAllowed: Boolean = false
-}
+)

--- a/biometricks/src/main/java/com/handstandsam/biometricks/BiometricPromptInfoExt.kt
+++ b/biometricks/src/main/java/com/handstandsam/biometricks/BiometricPromptInfoExt.kt
@@ -1,0 +1,23 @@
+package com.handstandsam.biometricks
+
+import androidx.biometric.BiometricPrompt
+
+/**
+ * Takes our [BiometricPromptInfo] and converts to AndroidX [BiometricPrompt.PromptInfo]
+ */
+fun BiometricPromptInfo.toAndroidX(): BiometricPrompt.PromptInfo {
+    val builder = BiometricPrompt.PromptInfo.Builder()
+    builder.setTitle(title)
+    builder.setNegativeButtonText(negativeButtonText)
+    builder.setConfirmationRequired(confirmationRequired)
+    builder.setDeviceCredentialAllowed(deviceCredentialAllowed)
+
+    subtitle?.let {
+        builder.setSubtitle(subtitle)
+    }
+    description?.let {
+        builder.setDescription(description)
+    }
+
+    return builder.build()
+}

--- a/biometricks/src/main/java/com/handstandsam/biometricks/Biometricks.kt
+++ b/biometricks/src/main/java/com/handstandsam/biometricks/Biometricks.kt
@@ -74,11 +74,7 @@ sealed class Biometricks {
          *     try {
          *         val unlockedCryptObject = Biometricks.showPrompt(
          *             this@MainActivity,
-         *             lockedCryptoObject,
-         *             BiometricPrompt.PromptInfo.Builder()
-         *                 .setTitle(...)
-         *                 .setNegativeButtonText(...)
-         *                 .build()
+         *             biometricPromptInfo
          *         ) { showLoading -> progressBar.visibility = if (showLoading) View.VISIBLE else View.INVISIBLE }
          *
          *         // success
@@ -92,28 +88,23 @@ sealed class Biometricks {
          * ```
          *
          * @param activity The host activity.
-         * @param cryptoObject The [BiometricPrompt.CryptoObject] to unlock. This is always required
-         * as you many not get 'secure' biometrics if you don't include it.
-         * @param promptInfo The [BiometricPrompt.PromptInfo] to display in the prompt.
+         * @param biometricPromptInfo The [BiometricPromptInfo] to display in the prompt.
          * @param showLoading Callback to show/hide a loading indicator for when there's a delay
          * showing the prompt. This is only used on api 28 as after that it shows immediately.
          */
         @MainThread
         suspend fun showPrompt(
             activity: FragmentActivity,
-            cryptoObject: BiometricPrompt.CryptoObject,
-            promptInfo: BiometricPrompt.PromptInfo,
+            promptInfo: BiometricPromptInfo,
             showLoading: (Boolean) -> Unit
         ): BiometricPrompt.CryptoObject {
-            UiHelpers.ensureFocus(activity)
-
             return UiHelpers.handleApi28Loading(activity, showLoading) {
                 suspendCoroutine<BiometricPrompt.CryptoObject> { continuation ->
                     BiometricPrompt(
                         activity,
                         ContextCompat.getMainExecutor(activity),
                         AuthenticationCallbackWrapper(continuation)
-                    ).authenticate(promptInfo, cryptoObject)
+                    ).authenticate(promptInfo.toAndroidX(), promptInfo.cryptoObject)
                 }
             }
         }
@@ -131,10 +122,7 @@ sealed class Biometricks {
          *         val unlockedCryptObject = Biometricks.showPrompt(
          *             this@MainActivity,
          *             lockedCryptoObject,
-         *             BiometricPrompt.PromptInfo.Builder()
-         *                 .setTitle(...)
-         *                 .setNegativeButtonText(...)
-         *                 .build()
+         *             biometricPromptInfo
          *         ) { showLoading -> progressBar.visibility = if (showLoading) View.VISIBLE else View.INVISIBLE }
          *
          *         // success
@@ -148,22 +136,18 @@ sealed class Biometricks {
          * ```
          *
          * @param fragment The host fragment.
-         * @param cryptoObject The [BiometricPrompt.CryptoObject] to unlock. This is always required
          * as you many not get 'secure' biometrics if you don't include it.
-         * @param promptInfo The [BiometricPrompt.PromptInfo] to display in the prompt.
+         * @param biometricPromptInfo The [BiometricPromptInfo] to display in the prompt.
          * @param showLoading Callback to show/hide a loading indicator for when there's a delay
          * showing the prompt. This is only used on api 28 as after that it shows immediately.
          */
         @MainThread
         suspend fun showPrompt(
             fragment: Fragment,
-            cryptoObject: BiometricPrompt.CryptoObject,
-            promptInfo: BiometricPrompt.PromptInfo,
+            promptInfo: BiometricPromptInfo,
             showLoading: (Boolean) -> Unit
         ): BiometricPrompt.CryptoObject {
             val activity = fragment.requireActivity()
-            
-            UiHelpers.ensureFocus(activity)
 
             return UiHelpers.handleApi28Loading(activity, showLoading) {
                 suspendCoroutine<BiometricPrompt.CryptoObject> { continuation ->
@@ -171,7 +155,7 @@ sealed class Biometricks {
                         fragment,
                         ContextCompat.getMainExecutor(activity),
                         AuthenticationCallbackWrapper(continuation)
-                    ).authenticate(promptInfo, cryptoObject)
+                    ).authenticate(promptInfo.toAndroidX(), promptInfo.cryptoObject)
                 }
             }
         }

--- a/biometricks/src/main/java/com/handstandsam/biometricks/Biometricks.kt
+++ b/biometricks/src/main/java/com/handstandsam/biometricks/Biometricks.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.FragmentActivity
 import com.handstandsam.biometricks.internal.AuthenticationCallbackWrapper
 import com.handstandsam.biometricks.internal.BiometricksHelper
 import com.handstandsam.biometricks.internal.UiHelpers
+import com.handstandsam.biometricks.internal.toAndroidX
 import kotlin.coroutines.suspendCoroutine
 
 /**

--- a/biometricks/src/main/java/com/handstandsam/biometricks/Biometricks.kt
+++ b/biometricks/src/main/java/com/handstandsam/biometricks/Biometricks.kt
@@ -99,7 +99,7 @@ sealed class Biometricks {
             promptInfo: BiometricPromptInfo,
             showLoading: (Boolean) -> Unit
         ): BiometricPrompt.CryptoObject {
-            return UiHelpers.handleApi28Loading(activity, showLoading) {
+            return UiHelpers.handleApi28LoadingAndEnsureFocus(activity, showLoading) {
                 suspendCoroutine<BiometricPrompt.CryptoObject> { continuation ->
                     BiometricPrompt(
                         activity,
@@ -150,7 +150,7 @@ sealed class Biometricks {
         ): BiometricPrompt.CryptoObject {
             val activity = fragment.requireActivity()
 
-            return UiHelpers.handleApi28Loading(activity, showLoading) {
+            return UiHelpers.handleApi28LoadingAndEnsureFocus(activity, showLoading) {
                 suspendCoroutine<BiometricPrompt.CryptoObject> { continuation ->
                     BiometricPrompt(
                         fragment,

--- a/biometricks/src/main/java/com/handstandsam/biometricks/internal/BiometricPromptInfoExt.kt
+++ b/biometricks/src/main/java/com/handstandsam/biometricks/internal/BiometricPromptInfoExt.kt
@@ -1,11 +1,12 @@
-package com.handstandsam.biometricks
+package com.handstandsam.biometricks.internal
 
 import androidx.biometric.BiometricPrompt
+import com.handstandsam.biometricks.BiometricPromptInfo
 
 /**
  * Takes our [BiometricPromptInfo] and converts to AndroidX [BiometricPrompt.PromptInfo]
  */
-fun BiometricPromptInfo.toAndroidX(): BiometricPrompt.PromptInfo {
+internal fun BiometricPromptInfo.toAndroidX(): BiometricPrompt.PromptInfo {
     val builder = BiometricPrompt.PromptInfo.Builder()
     builder.setTitle(title)
     builder.setNegativeButtonText(negativeButtonText)

--- a/biometricks/src/main/java/com/handstandsam/biometricks/internal/UiHelpers.kt
+++ b/biometricks/src/main/java/com/handstandsam/biometricks/internal/UiHelpers.kt
@@ -20,6 +20,8 @@ internal object UiHelpers {
         showLoading: (Boolean) -> Unit,
         showPrompt: suspend () -> T
     ): T {
+        ensureFocus(activity)
+
         // On api 28 if the user is locked out of biometrics from too many failed
         // attempts there will be a long delay before getting the error back. So the
         // user isn't confused as to what is going on, show a loading indicator.
@@ -65,7 +67,7 @@ internal object UiHelpers {
         }
     }
 
-    internal suspend fun ensureFocus(activity: Activity) {
+    private suspend fun ensureFocus(activity: Activity) {
         suspendCoroutine<Unit> { continuation ->
             // Showing the biometrics prompt will be ignored if the app does not have focus. You may
             // think that this will always be the case if you are resumed, it is not.

--- a/biometricks/src/main/java/com/handstandsam/biometricks/internal/UiHelpers.kt
+++ b/biometricks/src/main/java/com/handstandsam/biometricks/internal/UiHelpers.kt
@@ -15,7 +15,7 @@ import kotlin.coroutines.suspendCoroutine
  */
 internal object UiHelpers {
 
-    internal suspend fun <T> handleApi28Loading(
+    internal suspend fun <T> handleApi28LoadingAndEnsureFocus(
         activity: Activity,
         showLoading: (Boolean) -> Unit,
         showPrompt: suspend () -> T

--- a/sample/src/main/java/com/handstandsam/biometricks/sample/MainActivity.kt
+++ b/sample/src/main/java/com/handstandsam/biometricks/sample/MainActivity.kt
@@ -3,13 +3,12 @@ package com.handstandsam.biometricks.sample
 import android.os.Bundle
 import android.view.View
 import android.widget.Button
-import android.widget.ProgressBar
 import android.widget.TextView
 import android.widget.Toast
-import androidx.biometric.BiometricPrompt
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.lifecycleScope
 import com.handstandsam.biometricks.BiometricException
+import com.handstandsam.biometricks.BiometricPromptInfo
 import com.handstandsam.biometricks.Biometricks
 import com.handstandsam.biometricks.Biometricks.Available
 import com.handstandsam.biometricks.Biometricks.Available.*
@@ -63,18 +62,19 @@ class MainActivity : FragmentActivity() {
             try {
                 val unlockedCryptoObject = Biometricks.showPrompt(
                     this@MainActivity,
-                    cryptoObject,
-                    BiometricPrompt.PromptInfo.Builder()
-                        .setTitle("Authenticate with $biometricName")
-                        .setNegativeButtonText("Cancel")
-                        .setDeviceCredentialAllowed(false)
-                        .build()
+                    BiometricPromptInfo(
+                        title = "Authenticate with $biometricName",
+                        negativeButtonText = "Cancel",
+                        cryptoObject = cryptoObject
+                    )
                 ) { showLoading ->
                     findViewById<View>(R.id.loading).visibility =
                         if (showLoading) View.VISIBLE else View.INVISIBLE
                 }
 
                 showToast("Succeeded")
+
+                // TODO Do something with unlocked CryptoObject here
             } catch (e: BiometricException) {
                 if (e.shouldShow) {
                     showToast("Error | Message: ${e.errString} | Code: ${e.code}")


### PR DESCRIPTION
Cleanup to use our new data class BiometricPromptInfo to force CryptoObject, deviceCredential as false, and make API simpler and more Kotlin-esque.